### PR TITLE
Update HashConnectAPIProvider.tsx

### DIFF
--- a/src/HashConnectAPIProvider.tsx
+++ b/src/HashConnectAPIProvider.tsx
@@ -48,7 +48,7 @@ let APP_CONFIG: HashConnectTypes.AppMetadata = {
 };
 
 const loadLocalData = (): null | SaveData => {
-  let foundData = localStorage.getItem("  hashConnectData");
+  let foundData = localStorage.getItem("hashconnectData");
 
   if (foundData) {
     const saveData: SaveData = JSON.parse(foundData);


### PR DESCRIPTION
Updated the get call to the localStorage item to match the name set, this was preventing the local storage item from being loaded and affecting the state of the connection to the wallet.